### PR TITLE
Remove sendUpdates fn as part of crdt protocol.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL := build
 
 ifneq ($(CI), true)
 LOCAL_ARG = --local --verbose --diagnostics

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ type Transport {
   on(evt: 'message' | 'error'): Promise<void>
 }
 
-const clientA = crdtProtocol<Buffer>(async (message: Message<Buffer>) => {
-  await transportA.send(message)
-}, uuid())
+const clientA = crdtProtocol<Buffer>(uuid())
+const clientB = crdtProtocol<Buffer>(uuid())
 
-const clientB = crdtProtocol<Buffer>(async (message: Message<Buffer>) => {
-  await transportB.send(message)
-}, uuid())
+transportB.on('message', (message) => {
+  const msg = clientB.processMessage(message)
+  if (msg !== message) {
+    transportB.send(msg)
+  } else {
+    // we receive a new update. Update component.
+  }
+})
 
-transportA.on('message', clientA.processMessage)
-transportB.on('message', clientB.processMessage)
-
-const message = clientA.createEvent('keyA', Buffer.from('message'))
-await clientA.sendMessage(message)
+const message = clientA.createEvent('keyA', new TextEncoder().encode('DCL CRDT'))
+await transportA.sendMessage(message)
 ```

--- a/data/arraybuffer.test
+++ b/data/arraybuffer.test
@@ -4,7 +4,7 @@
 {"key":"key-A","data":"Hola","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"Hola","timestamp":1}
+{"key-A":{"timestamp":1,"data":"Hola"}}
 #
 # CRDT Uint8Array should return the bigger raw data
 # Messages sent over the wire
@@ -12,7 +12,7 @@
 {"key":"key-A","data":"a","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"b","timestamp":1}
+{"key-A":{"timestamp":1,"data":"b"}}
 #
 # CRDT Uint8Array should return the bigger raw data. a.byteLength !== b.byteLength
 # Messages sent over the wire
@@ -20,5 +20,5 @@
 {"key":"key-A","data":"aa","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"b","timestamp":1}
+{"key-A":{"timestamp":1,"data":"b"}}
 #

--- a/data/crdt.test
+++ b/data/crdt.test
@@ -3,14 +3,14 @@
 {"key":"key-A","data":"casla","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"casla","timestamp":1}
+{"key-A":{"timestamp":1,"data":"casla"}}
 #
 # CRDT protocol [Delay] one message with more clients (N > 2)
 # Messages sent over the wire
 {"key":"key-A","data":"casla","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"casla","timestamp":1}
+{"key-A":{"timestamp":1,"data":"casla"}}
 #
 # CRDT protocol [Delay] should decline message A if both messages are sent at the same time and data B > data A
 # Messages sent over the wire
@@ -18,7 +18,7 @@
 {"key":"key-A","data":"z","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"z","timestamp":1}
+{"key-A":{"timestamp":1,"data":"z"}}
 #
 # CRDT protocol [Delay] B > A but with more clients (N > 2)
 # Messages sent over the wire
@@ -26,7 +26,7 @@
 {"key":"key-A","data":"b","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"b","timestamp":1}
+{"key-A":{"timestamp":1,"data":"b"}}
 #
 # CRDT protocol [Delay] should store both keys
 # Messages sent over the wire
@@ -36,8 +36,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol [Delay] should store both keys, even if we send the messages in diff order z > a
 # Messages sent over the wire
@@ -47,8 +46,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol [Delay] same as before but with more clients (N > 2)
 # Messages sent over the wire
@@ -58,8 +56,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol [Delay] A, B and C send at the same time for the same key. Bigger raw should win
 # Messages sent over the wire
@@ -68,7 +65,7 @@
 {"key":"key-A","data":"C","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"z","timestamp":1}
+{"key-A":{"timestamp":1,"data":"z"}}
 #
 # CRDT protocol [Delay] A sends message, B has higher timestamp.
 # Messages sent over the wire
@@ -77,21 +74,21 @@
 {"key":"key-A","data":"C","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"B","timestamp":2}
+{"key-A":{"timestamp":2,"data":"B"}}
 #
 # CRDT protocol should store the message A in all the clients
 # Messages sent over the wire
 {"key":"key-A","data":"casla","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"casla","timestamp":1}
+{"key-A":{"timestamp":1,"data":"casla"}}
 #
 # CRDT protocol one message with more clients (N > 2)
 # Messages sent over the wire
 {"key":"key-A","data":"casla","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"casla","timestamp":1}
+{"key-A":{"timestamp":1,"data":"casla"}}
 #
 # CRDT protocol should decline message A if both messages are sent at the same time and data B > data A
 # Messages sent over the wire
@@ -99,7 +96,7 @@
 {"key":"key-A","data":"z","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"z","timestamp":1}
+{"key-A":{"timestamp":1,"data":"z"}}
 #
 # CRDT protocol B > A but with more clients (N > 2)
 # Messages sent over the wire
@@ -107,7 +104,7 @@
 {"key":"key-A","data":"b","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"b","timestamp":1}
+{"key-A":{"timestamp":1,"data":"b"}}
 #
 # CRDT protocol should store both keys
 # Messages sent over the wire
@@ -117,8 +114,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol should store both keys, even if we send the messages in diff order z > a
 # Messages sent over the wire
@@ -128,8 +124,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol same as before but with more clients (N > 2)
 # Messages sent over the wire
@@ -139,8 +134,7 @@
 {"key":"key-B","data":"z","timestamp":2}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"boedo","timestamp":1}
-{"key":"key-B","data":"z","timestamp":2}
+{"key-A":{"timestamp":1,"data":"boedo"},"key-B":{"timestamp":2,"data":"z"}}
 #
 # CRDT protocol A, B and C send at the same time for the same key. Bigger raw should win
 # Messages sent over the wire
@@ -149,7 +143,7 @@
 {"key":"key-A","data":"C","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"z","timestamp":1}
+{"key-A":{"timestamp":1,"data":"z"}}
 #
 # CRDT protocol A sends message, B has higher timestamp.
 # Messages sent over the wire
@@ -158,5 +152,5 @@
 {"key":"key-A","data":"C","timestamp":1}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"B","timestamp":2}
+{"key-A":{"timestamp":2,"data":"B"}}
 #

--- a/data/shuffle.test
+++ b/data/shuffle.test
@@ -6,7 +6,7 @@
 {"key":"key-A","data":"Message-0-2","timestamp":3}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"Message-0-2","timestamp":3}
+{"key-A":{"timestamp":3,"data":"Message-0-2"}}
 #
 # Process messages and get the same result should process all the messages and get the same state even if we sent them in a diff order
 # Messages sent over the wire
@@ -16,5 +16,5 @@
 {"key":"key-A","data":"Message-0-2","timestamp":3}
 # End of messages
 # Final CRDT State
-{"key":"key-A","data":"Message-0-2","timestamp":3}
+{"key-A":{"timestamp":3,"data":"Message-0-2"}}
 #

--- a/etc/crdt.api.md
+++ b/etc/crdt.api.md
@@ -7,14 +7,13 @@
 // @public
 export type CRDT<T = unknown> = {
     createEvent(key: string, data: T): Message<T>;
-    sendMessage(message: Message<T>): Promise<void>;
-    processMessage(message: Message<T>): Promise<T | void>;
+    processMessage(message: Message<T>): Message<T>;
     getState(): State<T>;
     getUUID(): string;
 };
 
 // @public
-export function crdtProtocol<T>(sendUpdates: SendUpdates<T>, id: string): CRDT<T>;
+export function crdtProtocol<T>(id: string): CRDT<T>;
 
 // @public
 export type Message<T = unknown> = {
@@ -33,9 +32,6 @@ export type Payload<T = unknown> = {
 //
 // @internal
 export function sameData<T = unknown>(a: T, b: T): boolean;
-
-// @public
-export type SendUpdates<T = unknown> = (message: Message<T>) => Promise<void>;
 
 // @public
 export type State<T = unknown> = Record<string, Payload<T> | undefined>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,19 +24,12 @@ export type Payload<T = unknown> = {
 export type State<T = unknown> = Record<string, Payload<T> | undefined>
 
 /**
- * Function to send updates to the other clients.
- * @public
- */
-export type SendUpdates<T = unknown> = (message: Message<T>) => Promise<void>
-
-/**
  * CRDT return type
  * @public
  */
 export type CRDT<T = unknown> = {
   createEvent(key: string, data: T): Message<T>
-  sendMessage(message: Message<T>): Promise<void>
-  processMessage(message: Message<T>): Promise<T | void>
+  processMessage(message: Message<T>): Message<T>
   getState(): State<T>
   getUUID(): string
 }

--- a/test/data.spec.ts
+++ b/test/data.spec.ts
@@ -1,0 +1,63 @@
+import expect from 'expect'
+import fs from 'fs-extra'
+import { CRDT, Message, State } from '../src/types'
+
+import { compareData, compareStatePayloads } from './utils'
+import { createSandbox } from './utils/sandbox'
+import { getDataPath, readByLine } from './utils/snapshot'
+const messages = []
+afterAll(() => {
+  // HACK to log all the messages after the describe/it logs for this test.
+  // 🧙‍♂️✨
+  setTimeout(() => {
+    messages.forEach((m) => process.stdout.write('\t' + m))
+  }, 0)
+})
+
+describe('CRDT process generated messages', () => {
+  it('> ', async () => {
+    const path = getDataPath('')
+    for await (const file of await fs.readdir(path)) {
+      let crdt = createSandbox({ clientLength: 1 }).clients[0]
+      let testSpecName: string
+      let nextLineIsState = false
+
+      function resetCrdt() {
+        nextLineIsState = false
+        testSpecName = undefined
+        crdt = createSandbox({ clientLength: 1 }).clients[0]
+      }
+
+      for await (const line of readByLine(file)) {
+        if (line === '#') continue
+
+        if (line.startsWith('#')) {
+          testSpecName ??= line
+        }
+
+        if (line === '# Final CRDT State') {
+          nextLineIsState = true
+          continue
+        }
+
+        if (line.startsWith('{') && line.endsWith('}')) {
+          const msg = JSON.parse(line)
+          if (nextLineIsState) {
+            const isValid = compareStatePayloads([crdt.getState(), msg])
+            expect.setState({ currentTestName: testSpecName })
+            if (!isValid) {
+              messages.push(`\x1b[31m✕ \x1b[0m${testSpecName} at [${file}]\n`)
+              expect(isValid).toBe(true)
+            } else {
+              messages.push(`\x1b[32m✓ \x1b[0m${testSpecName}(${file})\n`)
+            }
+            resetCrdt()
+          } else {
+            crdt.processMessage(msg)
+          }
+          continue
+        }
+      }
+    }
+  })
+})

--- a/test/data.spec.ts
+++ b/test/data.spec.ts
@@ -1,8 +1,7 @@
 import expect from 'expect'
 import fs from 'fs-extra'
-import { CRDT, Message, State } from '../src/types'
 
-import { compareData, compareStatePayloads } from './utils'
+import { compareStatePayloads } from './utils'
 import { createSandbox } from './utils/sandbox'
 import { getDataPath, readByLine } from './utils/snapshot'
 const messages = []
@@ -46,10 +45,10 @@ describe('CRDT process generated messages', () => {
             const isValid = compareStatePayloads([crdt.getState(), msg])
             expect.setState({ currentTestName: testSpecName })
             if (!isValid) {
-              messages.push(`\x1b[31m✕ \x1b[0m${testSpecName} at [${file}]\n`)
+              messages.push(`\x1b[31m✕ \x1b[0m${testSpecName}  [./${file}]\n`)
               expect(isValid).toBe(true)
             } else {
-              messages.push(`\x1b[32m✓ \x1b[0m${testSpecName}(${file})\n`)
+              messages.push(`\x1b[32m✓ \x1b[0m${testSpecName}  [./${file}]\n`)
             }
             resetCrdt()
           } else {


### PR DESCRIPTION
What ?
- CRDT now only receives and process its own messages. How we implement the transport and the broadcast its up to you.

- Add tests for the generated data files. Now we process all the data/*.tests files and process each message as a new crdt and then compare the states.

![image](https://user-images.githubusercontent.com/16782417/162859237-a012da0d-7275-4c3c-bf38-2a8aadc7375c.png)


![image](https://user-images.githubusercontent.com/16782417/162861801-471dfbef-478d-4966-97ba-20cc5f4103d8.png)
🤍 